### PR TITLE
zrunkbb: ensure data read from files is remembered

### DIFF
--- a/zkerrbb/zrunkbb.f
+++ b/zkerrbb/zrunkbb.f
@@ -124,6 +124,8 @@ C     observed photon energy between EAR(i) and EAR(i+1).
       external lenact, fgmodf
 
       save iread, lflagsav, rflagsav
+      save gi, ai, thetai, e, flux0
+
       data iread/0/
 
       ca = Mdd**0.25*Mbh**(-0.5)*fcol


### PR DESCRIPTION
I'm seeing that all-but-the-first call to this model (when used with Sherpa) return "random" data, and I think it's because of the missing SAVE statement.